### PR TITLE
ci: リリースワークフローを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build and zip for Chrome
+        run: |
+          bun run build
+          bun run zip
+
+      - name: Build and zip for Firefox
+        run: |
+          bun run build:firefox
+          bun run zip:firefox
+
+      - name: Get version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            .output/*.zip
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          name: Release v${{ steps.get_version.outputs.VERSION }}
+          body: |
+            ## ⚠️ 注意事項
+
+            **Firefox版は現在テストされていません。**
+            Chrome版のみ動作確認済みです。Firefox版をご利用の際は自己責任でお願いします。
+
+            ---
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
タグプッシュ時に自動でZIPファイルをビルドしてGitHub Releasesに公開する。
Chrome版とFirefox版の両方を含む。Firefox版は未テストのため注意書きを追加。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated release workflow for extension builds. Releases are now automatically published when version tags are pushed, with browser extension packages for Chrome and Firefox included as release assets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->